### PR TITLE
Recoil changes and New Easing Util

### DIFF
--- a/items/active/weapons/ranged/generated/combatrifle/combatrifles.config
+++ b/items/active/weapons/ranged/generated/combatrifle/combatrifles.config
@@ -1039,7 +1039,7 @@
           }
         },
 
-        // Elpis
+        // Elpis Single Fire
         "elpis1" : {
           "nameSuffix" : [ "of Trades", "" ],
           "rarity" : 2,
@@ -1131,6 +1131,8 @@
             "projectileCount" : 1.1
           }
         },
+
+        // Elpis Burst
         "elpis6" : {
           "nameSuffix" : [ "of Trades", "" ],
           "rarity" : 3,
@@ -1155,7 +1157,7 @@
           }
         },
 
-        // Vitrium
+        // Vitrium Burst
         "vitrium1" : {
           "nameSuffix" : [ "of Shards", "" ],
           "rarity" : 7,
@@ -1209,6 +1211,8 @@
             "projectileCount" : 1.0
           }
         },
+				
+				// Vitrium Burst
         "vitrium4" : {
           "nameSuffix" : [ "" ],
           "rarity" : 10,
@@ -1233,7 +1237,7 @@
           }
         },
 
-        // Vitrium
+        // Xenotox
         "xenotox1" : {
           "nameSuffix" : [ "'s Kiss" ],
           "rarity" : 7,

--- a/items/buildscripts/starforge-buildcombatrifle.lua
+++ b/items/buildscripts/starforge-buildcombatrifle.lua
@@ -212,7 +212,7 @@ function build(directory, config, parameters, level, seed)
 		end
 	end
 
-	config.primaryAbility = correctAbility(config, primaryAbilityMultipliers)
+	config.primaryAbility = correctAbility(config, primaryAbilityMultipliers, seed)
 
 	--Calculate damage level multiplier
 	config.damageLevelMultiplier = root.evalFunction("weaponDamageLevelMultiplier", configParameter("level", 1))
@@ -460,13 +460,13 @@ function getRandomKeyWithSeed(object, seed)
 end
 
 --Adjust ability based on new stats
-function correctAbility(config, primaryAbilityMultipliers)
+function correctAbility(config, primaryAbilityMultipliers, seed)
 	--Adjust recoil and firetimes to match firerate
 	local correctedAbility = nebUtil.multiplyTables(config.primaryAbility, primaryAbilityMultipliers)
 
 	--Adjust durations to match firetime with some hold on the fire stance
 	correctedAbility.stances.fire.duration = correctedAbility.fireTime * 0.02
-	correctedAbility.stances.cooldown.duration = correctedAbility.fireTime * 0.98
+	--correctedAbility.stances.cooldown.duration = correctedAbility.fireTime * 0.98
 
 	--Determine the amount to adjust the rotations by
 	local adjustFactor = ((correctedAbility.fireTime > 1) and math.max(1, (correctedAbility.fireTime - 1) * (correctedAbility.fireTime - 1) + 1) or correctedAbility.fireTime)
@@ -480,6 +480,10 @@ function correctAbility(config, primaryAbilityMultipliers)
 	correctedAbility.stances.cooldown.weaponRotation = correctedAbility.stances.fire.weaponRotation
 	correctedAbility.stances.cooldown.armRotation = correctedAbility.stances.fire.armRotation
 
+	
+	--local cooldownTime = correctedAbility.stances.cooldown.duration * (correctedAbility.burstCount or 1);
+	--sb.logInfo(string.format("seed %10d | fireType %s | RoF %7.4f | cooldown %7.4f | weaponRotation %7.4f", seed, correctedAbility.fireType, 1 / correctedAbility.fireTime, cooldownTime, correctedAbility.stances.fire.weaponRotation));
+	
 	--Ensure we dont get lower than 1 projectile count
 	correctedAbility.projectileCount = math.max(1, correctedAbility.projectileCount)
 

--- a/projectiles/explosions/starforge-behemothexplosion/starforge-behemothlingeringexplosion.projectile
+++ b/projectiles/explosions/starforge-behemothexplosion/starforge-behemothlingeringexplosion.projectile
@@ -6,7 +6,6 @@
   "animationCycle" : 0.4,
   "frameNumber" : 6,
   "physics" : "illusion",
-  "windupFrames" : 1,
   "bounces" : 0,
   "power" : 0,
   "speed" : 0,

--- a/scripts/c5easing.lua
+++ b/scripts/c5easing.lua
@@ -1,0 +1,35 @@
+if not c5Easing then
+	c5Easing = {};
+	
+	function c5Easing.lerp(progress, from, to)
+		return from + (to - from) * progress;
+	end
+	
+	-- clamps progress between 1 and 0
+	function c5Easing.limitProg(progress)
+		return math.min(1, math.max(0, progress));
+	end
+	
+	-- an equal amount of ease in
+	function c5Easing.easeInOut(progress, from, to)
+		return c5Easing.lerp(c5Easing.calcSig(c5Easing.limitProg(progress), 12, 1, 0.5, 0), from, to);
+	end
+	
+	function c5Easing.easeOut(progress, from, to)
+		return c5Easing.lerp(c5Easing.calcSig(c5Easing.limitProg(progress), 6, 2, 0, -0.5), from, to);
+	end
+	
+	function c5Easing.easeIn(progress, from, to)
+		return c5Easing.lerp(c5Easing.calcSig(c5Easing.limitProg(progress), 6, 2, 1, 0), from, to);
+	end
+	
+	function c5Easing.customEase(progress, from, to, xMult, yMult, xOffset, yOffset)
+		return c5Easing.lerp(c5Easing.calcSig(c5Easing.limitProg(progress), xMult, yMult, xOffset, yOffset), from, to);
+	end
+	
+	function c5Easing.calcSig(progress, xMult, yMult, xOffset, yOffset)
+		-- latex = y=y_{m}\left(\frac{1}{\left(1+\exp\left(-x_{m}\left(x-x_{o}\right)\right)\right)}+y_{o}\right)
+		return yMult * ( ( 1 / ( 1 + math.exp( -xMult * ( progress - xOffset ) ) ) ) + yOffset );
+	end
+
+end

--- a/tests/ci/check_json_assets.js
+++ b/tests/ci/check_json_assets.js
@@ -89,6 +89,7 @@ var globOptions = {
 	cwd: directory,
 	ignore: [
 		// Exclude everything that is not a JSON asset: images, documentation, examples, etc.
+		'LICENSE',
 		'tests',
 		'_previewimage',
 		'**/*.{lua,png,xcf,wav,ogg,txt,md,ase,aseprite,tsx,aup,ico,tmx,pdn,zip,au,old,unused}',


### PR DESCRIPTION
- Reworked the recoil animation in the starforge-gunfire to be better feeling and based on the previous actions. Burst length now equates to higher weapon offset.
- Added the c5Easing util script for all your easing needs. It includes easeIn, easeOut, easeInOut and a easeCustom. Ease Custom can be visualized by copying the latex in the sigmoid function into desmos and modifying the sliders. once you got the values just transcribe into your call and voila.
- added some identifiers in the combatrifle.config
- Fixed remote detonations causing crashes when the projectile no longer exists.
- Changed the recoil animation to terminate when the weapon is ready to fire again instead of leaving the weapon unable to fire for a seemingly arbitrary reason for no reason.
- added a filter to the part picker to make sure the part is made by the same manufacturer as the body.