### PR TITLE
Integrate Filter by Rarity functionality

### DIFF
--- a/interface/windowconfig/exaltingstation.config
+++ b/interface/windowconfig/exaltingstation.config
@@ -223,7 +223,48 @@
 		"rarities": {
 			"type": "radioGroup",
 			"toggleMode": true,
-			"buttons": []
+			"buttons" : [
+				{
+					"position" : [6, 60],
+					"baseImage" : "/interface/crafting/sortcommon.png",
+					"baseImageChecked" : "/interface/crafting/sortcommonselected.png",
+					"data" : {
+						"rarity" : [ "common" ]
+					}
+				},
+				{
+					"position" : [12, 60],
+					"baseImage" : "/interface/crafting/sortuncommon.png",
+					"baseImageChecked" : "/interface/crafting/sortuncommonselected.png",
+					"data" : {
+						"rarity" : [ "uncommon" ]
+					}
+				},
+				{
+					"position" : [18, 60],
+					"baseImage" : "/interface/crafting/sortrare.png",
+					"baseImageChecked" : "/interface/crafting/sortrareselected.png",
+					"data" : {
+						"rarity" : [ "rare" ]
+					}
+				},
+					{
+					"position" : [24, 60],
+					"baseImage" : "/interface/crafting/sortlegendary.png",
+					"baseImageChecked" : "/interface/crafting/sortlegendaryselected.png",
+					"data" : {
+						"rarity" : [ "legendary" ]
+					}
+				},
+				{
+					"position" : [30, 60],
+					"baseImage" : "/interface/crafting/sortessential.png",
+					"baseImageChecked" : "/interface/crafting/sortessentialselected.png",
+					"data" : {
+						"rarity" : [ "essential" ]
+					}
+				}
+			]
 		}
 	}
 }

--- a/interface/windowconfig/krythersloreshop.config
+++ b/interface/windowconfig/krythersloreshop.config
@@ -234,6 +234,46 @@
       "type" : "radioGroup",
       "toggleMode" : true,
       "buttons" : [
+        {
+          "position" : [6, 60],
+          "baseImage" : "/interface/crafting/sortcommon.png",
+          "baseImageChecked" : "/interface/crafting/sortcommonselected.png",
+          "data" : {
+            "rarity" : [ "common" ]
+          }
+        },
+        {
+          "position" : [12, 60],
+          "baseImage" : "/interface/crafting/sortuncommon.png",
+          "baseImageChecked" : "/interface/crafting/sortuncommonselected.png",
+          "data" : {
+            "rarity" : [ "uncommon" ]
+          }
+        },
+        {
+          "position" : [18, 60],
+          "baseImage" : "/interface/crafting/sortrare.png",
+          "baseImageChecked" : "/interface/crafting/sortrareselected.png",
+          "data" : {
+            "rarity" : [ "rare" ]
+          }
+        },
+        {
+          "position" : [24, 60],
+          "baseImage" : "/interface/crafting/sortlegendary.png",
+          "baseImageChecked" : "/interface/crafting/sortlegendaryselected.png",
+          "data" : {
+            "rarity" : [ "legendary" ]
+          }
+        },
+        {
+          "position" : [30, 60],
+          "baseImage" : "/interface/crafting/sortessential.png",
+          "baseImageChecked" : "/interface/crafting/sortessentialselected.png",
+          "data" : {
+            "rarity" : [ "essential" ]
+          }
+        }
       ]
     }
   }

--- a/interface/windowconfig/masamuneshop.config
+++ b/interface/windowconfig/masamuneshop.config
@@ -282,6 +282,46 @@
       "type" : "radioGroup",
       "toggleMode" : true,
       "buttons" : [
+        {
+          "position" : [6, 60],
+          "baseImage" : "/interface/crafting/sortcommon.png",
+          "baseImageChecked" : "/interface/crafting/sortcommonselected.png",
+          "data" : {
+            "rarity" : [ "common" ]
+          }
+        },
+        {
+          "position" : [12, 60],
+          "baseImage" : "/interface/crafting/sortuncommon.png",
+          "baseImageChecked" : "/interface/crafting/sortuncommonselected.png",
+          "data" : {
+            "rarity" : [ "uncommon" ]
+          }
+        },
+        {
+          "position" : [18, 60],
+          "baseImage" : "/interface/crafting/sortrare.png",
+          "baseImageChecked" : "/interface/crafting/sortrareselected.png",
+          "data" : {
+            "rarity" : [ "rare" ]
+          }
+        },
+        {
+          "position" : [24, 60],
+          "baseImage" : "/interface/crafting/sortlegendary.png",
+          "baseImageChecked" : "/interface/crafting/sortlegendaryselected.png",
+          "data" : {
+            "rarity" : [ "legendary" ]
+          }
+        },
+        {
+          "position" : [30, 60],
+          "baseImage" : "/interface/crafting/sortessential.png",
+          "baseImageChecked" : "/interface/crafting/sortessentialselected.png",
+          "data" : {
+            "rarity" : [ "essential" ]
+          }
+        }
       ]
     }
   }

--- a/interface/windowconfig/nadirshop.config
+++ b/interface/windowconfig/nadirshop.config
@@ -234,6 +234,46 @@
       "type" : "radioGroup",
       "toggleMode" : true,
       "buttons" : [
+        {
+          "position" : [6, 60],
+          "baseImage" : "/interface/crafting/sortcommon.png",
+          "baseImageChecked" : "/interface/crafting/sortcommonselected.png",
+          "data" : {
+            "rarity" : [ "common" ]
+          }
+        },
+        {
+          "position" : [12, 60],
+          "baseImage" : "/interface/crafting/sortuncommon.png",
+          "baseImageChecked" : "/interface/crafting/sortuncommonselected.png",
+          "data" : {
+            "rarity" : [ "uncommon" ]
+          }
+        },
+        {
+          "position" : [18, 60],
+          "baseImage" : "/interface/crafting/sortrare.png",
+          "baseImageChecked" : "/interface/crafting/sortrareselected.png",
+          "data" : {
+            "rarity" : [ "rare" ]
+          }
+        },
+        {
+          "position" : [24, 60],
+          "baseImage" : "/interface/crafting/sortlegendary.png",
+          "baseImageChecked" : "/interface/crafting/sortlegendaryselected.png",
+          "data" : {
+            "rarity" : [ "legendary" ]
+          }
+        },
+        {
+          "position" : [30, 60],
+          "baseImage" : "/interface/crafting/sortessential.png",
+          "baseImageChecked" : "/interface/crafting/sortessentialselected.png",
+          "data" : {
+            "rarity" : [ "essential" ]
+          }
+        }
       ]
     }
   }

--- a/interface/windowconfig/starforge.config
+++ b/interface/windowconfig/starforge.config
@@ -253,6 +253,46 @@
       "type" : "radioGroup",
       "toggleMode" : true,
       "buttons" : [
+        {
+          "position" : [6, 60],
+          "baseImage" : "/interface/crafting/sortcommon.png",
+          "baseImageChecked" : "/interface/crafting/sortcommonselected.png",
+          "data" : {
+            "rarity" : [ "common" ]
+          }
+        },
+        {
+          "position" : [12, 60],
+          "baseImage" : "/interface/crafting/sortuncommon.png",
+          "baseImageChecked" : "/interface/crafting/sortuncommonselected.png",
+          "data" : {
+            "rarity" : [ "uncommon" ]
+          }
+        },
+        {
+          "position" : [18, 60],
+          "baseImage" : "/interface/crafting/sortrare.png",
+          "baseImageChecked" : "/interface/crafting/sortrareselected.png",
+          "data" : {
+            "rarity" : [ "rare" ]
+          }
+        },
+        {
+          "position" : [24, 60],
+          "baseImage" : "/interface/crafting/sortlegendary.png",
+          "baseImageChecked" : "/interface/crafting/sortlegendaryselected.png",
+          "data" : {
+            "rarity" : [ "legendary" ]
+          }
+        },
+        {
+          "position" : [30, 60],
+          "baseImage" : "/interface/crafting/sortessential.png",
+          "baseImageChecked" : "/interface/crafting/sortessentialselected.png",
+          "data" : {
+            "rarity" : [ "essential" ]
+          }
+        }
       ]
     }
   }

--- a/interface/windowconfig/yukaishop.config
+++ b/interface/windowconfig/yukaishop.config
@@ -223,7 +223,48 @@
 		"rarities": {
 			"type": "radioGroup",
 			"toggleMode": true,
-			"buttons": []
+			"buttons": [
+				{
+					"position" : [6, 60],
+					"baseImage" : "/interface/crafting/sortcommon.png",
+					"baseImageChecked" : "/interface/crafting/sortcommonselected.png",
+					"data" : {
+						"rarity" : [ "common" ]
+					}
+				},
+				{
+					"position" : [12, 60],
+					"baseImage" : "/interface/crafting/sortuncommon.png",
+					"baseImageChecked" : "/interface/crafting/sortuncommonselected.png",
+					"data" : {
+						"rarity" : [ "uncommon" ]
+					}
+				},
+				{
+					"position" : [18, 60],
+					"baseImage" : "/interface/crafting/sortrare.png",
+					"baseImageChecked" : "/interface/crafting/sortrareselected.png",
+					"data" : {
+						"rarity" : [ "rare" ]
+					}
+				},
+					{
+					"position" : [24, 60],
+					"baseImage" : "/interface/crafting/sortlegendary.png",
+					"baseImageChecked" : "/interface/crafting/sortlegendaryselected.png",
+					"data" : {
+						"rarity" : [ "legendary" ]
+					}
+				},
+				{
+					"position" : [30, 60],
+					"baseImage" : "/interface/crafting/sortessential.png",
+					"baseImageChecked" : "/interface/crafting/sortessentialselected.png",
+					"data" : {
+						"rarity" : [ "essential" ]
+					}
+				}
+			]
 		}
 	}
 }


### PR DESCRIPTION
Covers the crafting station window configs that I am aware of. May be pointless on the Exalting Station as all items in it are the same rarity by default.
<img width="672" height="516" alt="image" src="https://github.com/user-attachments/assets/7a9ce68d-602a-4a62-9ecc-9e95f8c46d95" />
<img width="672" height="516" alt="image" src="https://github.com/user-attachments/assets/10ec1423-44e7-4557-94d0-7d5a48df5363" />